### PR TITLE
Se centralizaron las constantes (imágenes, textos e identificadores)

### DIFF
--- a/UalaTest/Common/Helper/Constants.swift
+++ b/UalaTest/Common/Helper/Constants.swift
@@ -1,0 +1,37 @@
+//
+//  Constants.swift
+//  UalaTest
+//
+//  Created by Juan Esteban Pelaez on 5/01/25.
+//
+import Foundation
+
+enum Constants {
+    static let urlBase = "https://gist.githubusercontent.com/hernan-uala"
+    static let endPointCities = "dce8843a8edbe0b0018b32e137bc2b3a/raw/0996accf70cb0ca0e16f9a99e0ee185fafca7af1/cities.json"
+    
+    static let downloadedData = "downloadedData"
+    
+    enum Messages {
+        static let downloading = "Downloading cities..."
+        
+        static let placeholder = "Filter"
+        static let notFovourites = "No favourites"
+        static let notMatches = "No matches found"
+    }
+    
+    enum Images {
+        static let startFill = "star.fill"
+        static let start = "star"
+        
+        static let magnifying = "magnifyingglass"
+        static let xmark = "xmark.circle.fill"
+    }
+    
+    enum Identifiers {
+        static let mapDetail = "mapDetail"
+        static let landscapeCities = "landscapeCities"
+        static let favourites = "favourites"
+    }
+    
+}

--- a/UalaTest/Common/Managers/DataManager.swift
+++ b/UalaTest/Common/Managers/DataManager.swift
@@ -43,8 +43,13 @@ class DataManager: DataManagerProtocol {
             SortDescriptor(\.name, order: .forward),
             SortDescriptor(\.country, order: .forward)
         ])
-        request.fetchLimit = 500 /// Se establece en máximo 500 registros para respuesta mas rápida y para no sobrecargar las vistas
-                                 /// Esto limita el total de los resultados, pero lo considero una buena practica al realizar busquedas en tiempo real
+        
+        /// Se establece en máximo 500 registros para respuesta mas rápida y para no sobrecargar las vistas para busquedas especificas
+        /// Esto limita el total de los resultados, pero lo considero una buena practica al realizar busquedas en tiempo real
+        
+        let limit = predicate == nil ? 3000 : 500   /// 3000 registros cuando muestre todo el listado
+        
+        request.fetchLimit = limit
         return request
     }
     

--- a/UalaTest/Common/Managers/PreferencesManager.swift
+++ b/UalaTest/Common/Managers/PreferencesManager.swift
@@ -12,7 +12,7 @@ class PreferencesManager: ObservableObject {
     static let shared = PreferencesManager()
     
     /// Se usa esta variable para mostrar la vista de carga `SplasView` o la vista de la lista de ciudades en el `ContentView`, esta propiedad se guarda en los Defaults
-    @AppStorage(Constants.downloadedData.rawValue)
+    @AppStorage(Constants.downloadedData)
     var downloadedData: Bool = false
     
 }

--- a/UalaTest/Common/Network/APIManager+Extension.swift
+++ b/UalaTest/Common/Network/APIManager+Extension.swift
@@ -38,10 +38,3 @@ enum HTTPHeader {
     
     static let applicationJson = "application/json;charset=UTF-8"
 }
-
-enum Constants: String {
-    case urlBase = "https://gist.githubusercontent.com/hernan-uala"
-    case endPointCities = "dce8843a8edbe0b0018b32e137bc2b3a/raw/0996accf70cb0ca0e16f9a99e0ee185fafca7af1/cities.json"
-    
-    case downloadedData = "downloadedData"
-}

--- a/UalaTest/Components/SearchBar.swift
+++ b/UalaTest/Components/SearchBar.swift
@@ -16,10 +16,10 @@ struct SearchBar: View {
     var body: some View {
         let color = Color.black.opacity(0.8)
         HStack {
-            Image(systemName: "magnifyingglass")
+            Image(systemName: Constants.Images.magnifying)
             TextField(placeHolder, text: $searchText)
             if !self.searchText.isEmpty {
-                Image(systemName: "xmark.circle.fill")
+                Image(systemName:  Constants.Images.xmark)
                     .imageScale(.medium)
                     .foregroundColor(Color(.systemGray2))
                     .padding(3)

--- a/UalaTest/Domain/Cities/Detail/DetailView.swift
+++ b/UalaTest/Domain/Cities/Detail/DetailView.swift
@@ -25,7 +25,7 @@ struct DetailView: View {
                                         maximumDistance: 20000)) {
                 Marker(item.name, coordinate: coordinate)
             }
-            .accessibilityIdentifier("mapDetail")
+            .accessibilityIdentifier(Constants.Identifiers.mapDetail)
             .navigationTitle(name)
             .onReceive(inspection.notice) { self.inspection.visit(self, $0) }
         }

--- a/UalaTest/Domain/Cities/Home/LandCitiesView.swift
+++ b/UalaTest/Domain/Cities/Home/LandCitiesView.swift
@@ -15,7 +15,7 @@ struct LandCitiesView: View {
             DetailView()
                 .frame(maxWidth: .infinity)
         }
-        .accessibilityIdentifier("landscapeCities")
+        .accessibilityIdentifier(Constants.Identifiers.landscapeCities)
     }
     
 }

--- a/UalaTest/Domain/Cities/List/CitiesListView.swift
+++ b/UalaTest/Domain/Cities/List/CitiesListView.swift
@@ -15,31 +15,32 @@ struct CitiesListView: View {
     @State private var showFavourites = false
     
     internal let inspection = Inspection<Self>()
-
+    
     var body: some View {
         VStack {
             HStack {
-                SearchBar(placeHolder: "Filter", searchText: $textObserver.searchText)
+                SearchBar(placeHolder: Constants.Messages.placeholder, searchText: $textObserver.searchText)
                     .padding(8)
                 Button(action: {
                     self.showFavourites.toggle() /// Me muestra u oculta los favoritos
                     self.checkFetch()
                 }) {
-                    Image(systemName: self.showFavourites ? "star.fill": "star")
+                    let image = self.showFavourites ? Constants.Images.startFill: Constants.Images.start
+                    Image(systemName: image)
                         .resizable()
                         .frame(width: 24, height: 24)
                         .padding(.trailing)
                 }
-                .accessibilityIdentifier("favourites")
+                .accessibilityIdentifier(Constants.Identifiers.favourites)
             }
             
             let items = self.viewModel.items
             
             if items.isEmpty {
                 if self.showFavourites {
-                    self.emptyListView("No favourites")
+                    self.emptyListView(Constants.Messages.notFovourites)
                 } else if !self.textObserver.searchText.isEmpty {
-                    self.emptyListView("No matches found")
+                    self.emptyListView(Constants.Messages.notMatches)
                 }
             }
             

--- a/UalaTest/Domain/Cities/List/CityItemView.swift
+++ b/UalaTest/Domain/Cities/List/CityItemView.swift
@@ -14,10 +14,10 @@ struct CityItemView: View {
     var body: some View {
         HStack {
             VStack {
-                Text("\(dataItem.name), \(self.dataItem.country)")
+                Text("\(self.dataItem.name), \(self.dataItem.country)")
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .font(.headline)
-                Text("\(dataItem.lat), \(self.dataItem.lon)")
+                Text("\(self.dataItem.lat), \(self.dataItem.lon)")
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .font(.caption)
                     .foregroundStyle(Color.gray)
@@ -26,7 +26,8 @@ struct CityItemView: View {
                 /// Modifico el item para que se marque como favorito o no, con SwiftData no requiero hacer ningun otro proceso ya que lo cambia en tiempo real en el modelo almacenado y queda auto guardado
                 self.dataItem.isBookmark.toggle()
             }, label: {
-                Image(systemName: self.dataItem.isBookmark ? "star.fill": "star")
+                let image = self.dataItem.isBookmark ? Constants.Images.startFill: Constants.Images.start
+                Image(systemName: image)
                     .resizable()
                     .frame(width: 24, height: 24)
             })

--- a/UalaTest/Domain/Splash/SplashView.swift
+++ b/UalaTest/Domain/Splash/SplashView.swift
@@ -21,7 +21,7 @@ struct SplashView: View {
             ProgressView()
                 .progressViewStyle(CircularProgressViewStyle(tint: .blue))
                 .scaleEffect(2.0, anchor: .center)
-            Text("Downloading cities...")
+            Text(Constants.Messages.downloading)
                 .font(.title)
         }
         .task {

--- a/UalaTest/Domain/Splash/SplashViewModel.swift
+++ b/UalaTest/Domain/Splash/SplashViewModel.swift
@@ -27,8 +27,8 @@ class SplashViewModel {
             return
         }
         
-        let request = APIRequestBuilder(urlApi: Constants.urlBase.rawValue)
-            .withEndPoint(Constants.endPointCities.rawValue)
+        let request = APIRequestBuilder(urlApi: Constants.urlBase)
+            .withEndPoint(Constants.endPointCities)
             .withMethod(.get)
             .build()
         

--- a/UalaTestTests/Manager/ApiManagerTests.swift
+++ b/UalaTestTests/Manager/ApiManagerTests.swift
@@ -84,10 +84,5 @@ final class ApiManagerTests: XCTestCase {
         
         wait(for: [expectation], timeout: 3.0)
     }
-    
-    func testContentView() {  // Note: `async`
-        let sut = ContentView()
-        XCTAssertNotNil(sut)
-    }
 
 }

--- a/UalaTestTests/UalaTestUITests.swift
+++ b/UalaTestTests/UalaTestUITests.swift
@@ -22,7 +22,7 @@ final class UalaTestUITests: XCTestCase {
         let sut = SplashView(viewModel: SplashViewModel(apiManager: MockApiManager.shared, dataManager: MockDataManager.shared))
         
         let value = try sut.inspect().implicitAnyView().vStack().text(1).string()
-        XCTAssertEqual(value, "Downloading cities...")
+        XCTAssertEqual(value, Constants.Messages.downloading)
     }
     
     func testContentView() throws {
@@ -33,7 +33,7 @@ final class UalaTestUITests: XCTestCase {
         
         let sutSplash = try sut.inspect().find(SplashView.self).actualView()
         let valueSplash = try sutSplash.inspect().implicitAnyView().vStack().text(1).string()
-        XCTAssertEqual(valueSplash, "Downloading cities...")
+        XCTAssertEqual(valueSplash, Constants.Messages.downloading)
         
         PreferencesManager.shared.downloadedData = true
         
@@ -45,13 +45,13 @@ final class UalaTestUITests: XCTestCase {
     func testLandCitiesView() throws {
         let sut = LandCitiesView()
         let value = try sut.inspect().implicitAnyView().hStack().accessibilityIdentifier()
-        XCTAssertEqual(value, "landscapeCities")
+        XCTAssertEqual(value, Constants.Identifiers.landscapeCities)
     }
     
     func testSearchBar() throws {
         let search = Binding<String>(wrappedValue: "Hola")
     
-        let sut = SearchBar(placeHolder: "Placeholder", searchText: search)
+        let sut = SearchBar(placeHolder: Constants.Messages.placeholder, searchText: search)
         try sut.inspect().implicitAnyView().hStack().image(2).callOnTapGesture()
         
         XCTAssertTrue(search.wrappedValue.isEmpty)
@@ -68,7 +68,7 @@ final class UalaTestUITests: XCTestCase {
         let exp = sut.inspection.inspect { view in
             let button = try view.implicitAnyView().vStack().hStack(0).button(1)
             try button.tap()
-            XCTAssertEqual(try button.accessibilityIdentifier(), "favourites")
+            XCTAssertEqual(try button.accessibilityIdentifier(), Constants.Identifiers.favourites)
         }
         
         ViewHosting.host(view: sut.environment(viewModel))
@@ -86,7 +86,7 @@ final class UalaTestUITests: XCTestCase {
         
         let exp = sut.inspection.inspect { view in
             let value = try view.implicitAnyView().map().accessibilityIdentifier()
-            XCTAssertEqual(value, "mapDetail")
+            XCTAssertEqual(value, Constants.Identifiers.mapDetail)
         }
                 
         ViewHosting.host(view: sut.environment(viewModel))


### PR DESCRIPTION
Para la lista inicial de ciudades, se paso de 500 a 3000 registros, cuando no hay filtro